### PR TITLE
fix: removeHost only splice changed lines

### DIFF
--- a/src/SimpleHosts.ts
+++ b/src/SimpleHosts.ts
@@ -141,7 +141,7 @@ export class SimpleHosts {
                     changed = true;
                 }
             }
-            if (tokens.length < 2) {
+            if (changed && tokens.length < 2) {
                 lines.splice(i, 1);
             } else if (changed) {
                 lines[i] = tokens.join('\t');


### PR DESCRIPTION
Fixes a problem on removeHost all non token lines like comments or formatting newlines get lost